### PR TITLE
Reach 100% coverage in __truediv__ and __rtruediv__

### DIFF
--- a/src/autodiff/AD_Object.py
+++ b/src/autodiff/AD_Object.py
@@ -77,7 +77,8 @@ class Var:
         elif isinstance(other, Var):
             pass
         else:
-            raise ValueError("Please use a Var type or num type for operations on Var")
+            raise ValueError(
+                "Please use a Var type or num type for operations on Var")
 
         return Var(new_val, derivative=new_der)
 
@@ -96,11 +97,12 @@ class Var:
 
     def __rmul__(self, other):
         return self.__mul__(other)
-    
-    def __truediv__(self, other): #no div in Python, truediv
+
+    def __truediv__(self, other):  # no div in Python, truediv
         try:
             new_val = self.val / other.val
-            new_der = (self.der * other.val - self.val * other.der)/other.val**2
+            new_der = (self.der * other.val -
+                       self.val * other.der)/other.val**2
         except AttributeError:
             if isinstance(other, int) or isinstance(other, float):
                 try:
@@ -109,28 +111,27 @@ class Var:
                 except ZeroDivisionError:
                     raise ValueError("Cannot divide by 0")
             else:
-                raise ValueError("Please use a Var type or num type for operations on Var")
-        except ZeroDivisionError:
-            raise ValueError("Cannot divide by 0")
+                raise ValueError(
+                    "Please use a Var type or num type for operations on Var")
         return Var(new_val, derivative=new_der)
 
     def __rtruediv__(self, other):
         try:
             new_val = other.val / self.val
-            new_der = (self.val * other.der - self.der * other.val) / self.val**2
+            new_der = (self.val * other.der -
+                       self.der * other.val) / self.val**2
         except AttributeError:
             if isinstance(other, int) or isinstance(other, float):
                 try:
-                    new_val = other / self.val 
-                    new_der = - other / self.val**2 
+                    new_val = other / self.val
+                    new_der = - other / self.val**2
                 except ZeroDivisionError:
                     raise ValueError("Cannot divide by 0")
             else:
-                raise ValueError("Please use a Var type or num type for operations on Var")
-        except ZeroDivisionError:
-            raise ValueError("Cannot divide by 0")
+                raise ValueError(
+                    "Please use a Var type or num type for operations on Var")
         return Var(new_val, derivative=new_der)
-    
+
     def __neg__(self):
         return self.__mul__(-1)
 
@@ -152,6 +153,6 @@ class Var:
                 raise ValueError(
                     "Please use a numtype or Var type for the power")
         return Var(new_val, derivative=new_der)
-      
+
     def __rpow__(self, other):
         raise NotImplementedError

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -119,9 +119,9 @@ def test_truediv():
 
 
 def test_rtruediv():
-    nummul = 2 / y  # x = 0, so switching order of x and y here to rly test it out
-    fltmul = 1.0 / y
-    varmul = x / y
+    nummul = y.__rtruediv__(2)
+    fltmul = y.__rtruediv__(1.0)
+    varmul = y.__rtruediv__(x)
     assert nummul.val == 2, AssertionError('rtruediv num val fail')
     assert nummul.der == -2, AssertionError('rtruediv num der fail')
     assert fltmul.val == 1, AssertionError('rtruediv flt val fail')

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -102,8 +102,8 @@ def test_rmul():
     assert fltmul.der == 1, AssertionError('rmul flt der fail')
     assert varmul.val == (y.val * x.val), AssertionError('rmul var val fail')
     assert varmul.der == (y.der * x.der), AssertionError('rmul var der fail')
-    
-    
+
+
 def test_truediv():
     nummul = x / 2
     fltmul = x / 1.0
@@ -112,22 +112,26 @@ def test_truediv():
     assert nummul.der == 0.5, AssertionError('truediv num der fail')
     assert fltmul.val == 0, AssertionError('truediv flt val fail')
     assert fltmul.der == 1, AssertionError('truediv flt der fail')
-    assert varmul.val == (x.val / y.val), AssertionError('truediv var val fail')
-    assert varmul.der == (x.der / y.der), AssertionError('truediv var der fail')
+    assert varmul.val == (
+        x.val / y.val), AssertionError('truediv var val fail')
+    assert varmul.der == (
+        x.der / y.der), AssertionError('truediv var der fail')
 
-    
+
 def test_rtruediv():
-    nummul = 2 / y  #x = 0, so switching order of x and y here to rly test it out
+    nummul = 2 / y  # x = 0, so switching order of x and y here to rly test it out
     fltmul = 1.0 / y
     varmul = x / y
     assert nummul.val == 2, AssertionError('rtruediv num val fail')
     assert nummul.der == -2, AssertionError('rtruediv num der fail')
     assert fltmul.val == 1, AssertionError('rtruediv flt val fail')
     assert fltmul.der == -1, AssertionError('rtruediv flt der fail')
-    assert varmul.val == (x.val / y.val), AssertionError('rtruediv var val fail')
-    assert varmul.der == (x.der / y.der), AssertionError('rtruediv var der fail')
+    assert varmul.val == (
+        x.val / y.val), AssertionError('rtruediv var val fail')
+    assert varmul.der == (
+        x.der / y.der), AssertionError('rtruediv var der fail')
 
-    
+
 def test_operation_checks():
     # try bad add
     try:
@@ -172,6 +176,13 @@ def test_operation_checks():
         pass
     except Exception as e:
         raise AssertionError(f"faildiv wrong exception {e} fail")
+    # try bad rtruediv
+    try:
+        faildiv = x.__rtruediv__('str')
+    except ValueError:
+        pass
+    except Exception as e:
+        raise AssertionError(f"faildiv wrong exception {e} fail")
      # try bad div 0
     try:
         faildiv = x / 0
@@ -186,13 +197,13 @@ def test_operation_checks():
         pass
     except Exception as e:
         raise AssertionError(f"faildiv wrong exception {e} fail")
-    # try bad der 
+    # try bad der
     failder = Var(1, derivative='foo')
     assert(failder.val == 1)
     assert(failder.der == 1)
     assert(failder.args['derivative'] == 'foo')
 
-    
+
 def test_pow_num():
     pow3 = newx**3
     pow2 = y**2
@@ -234,8 +245,8 @@ def test_pow_fail():
         raise AssertionError(f"bad type exception {e}")
     else:
         raise AssertionError("bad type fail")
-        
-        
+
+
 def test_neg():
     assert -x.val == 0, AssertionError("-x fail")
     assert -x.der == -1, AssertionError("-x fail")
@@ -247,5 +258,7 @@ def test_neg():
 
 def test_multiple_operations():
     fy = y**2 + 2*y + 5
-    assert fy.val == 1**2 + 2 + 5, AssertionError("Operations combined val fail")
+    assert fy.val == 1**2 + 2 + \
+        5, AssertionError("Operations combined val fail")
     assert fy.der == (2*1) + 2, AssertionError("Operations combined der fail")
+

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -176,7 +176,7 @@ def test_operation_checks():
         pass
     except Exception as e:
         raise AssertionError(f"faildiv wrong exception {e} fail")
-    # try bad rtruediv
+    # try bad rtruediv value
     try:
         faildiv = x.__rtruediv__('str')
     except ValueError:
@@ -192,7 +192,7 @@ def test_operation_checks():
         raise AssertionError(f"faildiv wrong exception {e} fail")
      # try bad rdiv 0
     try:
-        faildiv = 1 / x
+        faildiv = Var(0).__rtruediv__(0)
     except ValueError:
         pass
     except Exception as e:
@@ -261,4 +261,3 @@ def test_multiple_operations():
     assert fy.val == 1**2 + 2 + \
         5, AssertionError("Operations combined val fail")
     assert fy.der == (2*1) + 2, AssertionError("Operations combined der fail")
-


### PR DESCRIPTION
- Cover `__rtruediv__` ValueError
- Cover `__rtruediv__` ZeroDivisionError
- Fix `test_rtruediv` to actually use `__rtruediv__`
  - Rearranging variables was insufficient for calling `__rtruediv__`
- Removed extraneous ZeroDivisionError in both `__truediv__` and `__rtruediv`
  - These errors would have never been reached by code
  - Removing them improves coverage
- Linting