### PR TITLE
Rewrite __rtruediv__ and its unit tests

### DIFF
--- a/src/autodiff/AD_Object.py
+++ b/src/autodiff/AD_Object.py
@@ -116,21 +116,10 @@ class Var:
         return Var(new_val, derivative=new_der)
 
     def __rtruediv__(self, other):
-        try:
-            new_val = other.val / self.val
-            new_der = (self.val * other.der -
-                       self.der * other.val) / self.val**2
-        except AttributeError:
-            if isinstance(other, int) or isinstance(other, float):
-                try:
-                    new_val = other / self.val
-                    new_der = - other / self.val**2
-                except ZeroDivisionError:
-                    raise ValueError("Cannot divide by 0")
-            else:
-                raise ValueError(
-                    "Please use a Var type or num type for operations on Var")
-        return Var(new_val, derivative=new_der)
+        if not (isinstance(other, int) or isinstance(other, float)):
+            raise ValueError(
+                "Please use a Var type or num type for operations on Var")
+        return Var(other, derivative=0).__truediv__(self)
 
     def __neg__(self):
         return self.__mul__(-1)

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -120,17 +120,12 @@ def test_truediv():
 
 
 def test_rtruediv():
-    nummul = y.__rtruediv__(2)
-    fltmul = y.__rtruediv__(1.0)
-    varmul = y.__rtruediv__(x)
+    nummul = 2 / y
+    fltmul = 1.0 / y
     assert nummul.val == 2, AssertionError('rtruediv num val fail')
     assert nummul.der == -2, AssertionError('rtruediv num der fail')
     assert fltmul.val == 1, AssertionError('rtruediv flt val fail')
     assert fltmul.der == -1, AssertionError('rtruediv flt der fail')
-    assert varmul.val == (
-        x.val / y.val), AssertionError('rtruediv var val fail')
-    assert varmul.der == (
-        x.der / y.der), AssertionError('rtruediv var der fail')
 
 
 def test_operation_checks():
@@ -179,7 +174,7 @@ def test_operation_checks():
         raise AssertionError(f"faildiv wrong exception {e} fail")
     # try bad rtruediv value
     try:
-        faildiv = x.__rtruediv__('str')
+        faildiv = 'str' / y
     except ValueError:
         pass
     except Exception as e:
@@ -187,13 +182,6 @@ def test_operation_checks():
      # try bad div 0
     try:
         faildiv = x / 0
-    except ValueError:
-        pass
-    except Exception as e:
-        raise AssertionError(f"faildiv wrong exception {e} fail")
-     # try bad rdiv 0
-    try:
-        faildiv = Var(0).__rtruediv__(0)
     except ValueError:
         pass
     except Exception as e:


### PR DESCRIPTION
- Refactor `__rtruediv__` to use `__truediv__`
  - This reduces code duplication
- Rewrite `__rtruediv__` unit tests
  - No longer explicitly calls `__rtruediv__` but rather expressions that should call `__rtruediv__`
    - e.g. `y.__rtruediv__(2)` becomes `2/y`
  - Remove unit test `x/y`
    - This is covered by `__truediv__`; `__rtruediv__` will never run it