### PR TITLE
Rewrite __rsub__ to remove code duplication

### DIFF
--- a/src/autodiff/AD_Object.py
+++ b/src/autodiff/AD_Object.py
@@ -69,18 +69,10 @@ class Var:
         return Var(new_val, derivative=new_der)
 
     def __rsub__(self, other):
-        new_val = -self.val
-        new_der = -self.der
-        if isinstance(other, (int, float)):
-            new_val = other - self.val
-            new_der = -self.der
-        elif isinstance(other, Var):
-            pass
-        else:
+        if not (isinstance(other, int) or isinstance(other, float)):
             raise ValueError(
                 "Please use a Var type or num type for operations on Var")
-
-        return Var(new_val, derivative=new_der)
+        return Var(other, derivative=0).__sub__(self)
 
     def __mul__(self, other):
         try:

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -70,15 +70,12 @@ def test_sub():
 
 
 def test_rsub():
-    numsub = 2-x
-    fltsub = 1.0-x
-    varsub = y - x
+    numsub = 2 - x
+    fltsub = 1.0 - x
     assert numsub.val == 2, AssertionError('rSub num val fail')
     assert numsub.der == -1, AssertionError('rSub num der fail')
     assert fltsub.val == 1, AssertionError('rSub flt val fail')
     assert fltsub.der == -1, AssertionError('rSub flt der fail')
-    assert varsub.val == (y.val - x.val), AssertionError('rSub var val fail')
-    assert varsub.der == (y.der - x.der), AssertionError('rSub var der fail')
 
 
 def test_mul():


### PR DESCRIPTION
- Call `__sub__` in `__rsub__` instead of rewriting subtraction logic
- Remove extraneous unit test that never calls `__rsub__`