### PR TITLE
Implement more comprehensive type checking in __rpow__

### DIFF
--- a/src/autodiff/AD_Object.py
+++ b/src/autodiff/AD_Object.py
@@ -155,8 +155,8 @@ class Var:
         return Var(new_val, derivative=new_der)
 
     def __rpow__(self, other):
-        # Cover case in which other is an int or float
-        if isinstance(other, int) or isinstance(other, float):
-            # Convert to Var
-            other = Var(other, derivative=0)
-        return other.__pow__(self)
+        # Cover case in which other is invalid type
+        if not (isinstance(other, int) or isinstance(other, float)):
+            raise ValueError(
+                "Please use a Var type or num type for operations on Var")
+        return Var(other, derivative=0).__pow__(self)

--- a/src/autodiff/AD_Object.py
+++ b/src/autodiff/AD_Object.py
@@ -157,6 +157,7 @@ class Var:
     def __rpow__(self, other):
         # Cover case in which other is invalid type
         if not (isinstance(other, int) or isinstance(other, float)):
+            print("test")
             raise ValueError(
                 "Please use a Var type or num type for operations on Var")
         return Var(other, derivative=0).__pow__(self)

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -232,16 +232,6 @@ def test_rpow_num():
     assert rpow3.val == 3**2, AssertionError("3**2 val fail")
     assert rpow3.der == 3**2 * np.log(3), AssertionError("3**2 der fail")
 
-
-def test_rpow_var():
-    xy = newx**y
-    yx = y**newx
-    assert xy.val == y.__rpow__(newx).val, AssertionError("var pow val fail")
-    assert xy.der == y.__rpow__(newx).der, AssertionError("var pow derfail")
-    assert yx.der == newx.__rpow__(y).der, AssertionError("var pow val fail")
-    assert yx.val == newx.__rpow__(y).val, AssertionError("var pow der fail")
-
-
 def test_pow_fail():
     # 0^x der fail
     try:

--- a/tests/test_AD_Object.py
+++ b/tests/test_AD_Object.py
@@ -232,6 +232,7 @@ def test_rpow_num():
     assert rpow3.val == 3**2, AssertionError("3**2 val fail")
     assert rpow3.der == 3**2 * np.log(3), AssertionError("3**2 der fail")
 
+
 def test_pow_fail():
     # 0^x der fail
     try:
@@ -246,6 +247,18 @@ def test_pow_fail():
     # Type checking
     try:
         y**('hello')
+    except ValueError:
+        pass
+    except Exception as e:
+        raise AssertionError(f"bad type exception {e}")
+    else:
+        raise AssertionError("bad type fail")
+
+
+def test_rpow_fail():
+    # Type checking
+    try:
+        'str' ** x
     except ValueError:
         pass
     except Exception as e:


### PR DESCRIPTION
- Returns ValueError if `other` is neither int/float
- Remove extraneous unit test function that tests `__pow__`, not `__rpow__`